### PR TITLE
Allow Zoom to be Disabled

### DIFF
--- a/src/Graphviz.tsx
+++ b/src/Graphviz.tsx
@@ -36,6 +36,11 @@ export class Graphviz extends React.Component<IGraphvizProps, any> {
 
   private renderGraph = () => {
     const { dot, options } = this.props;
+
+    if (!options?.zoom) {
+      document.querySelector(`#${this.id}`)?.childNodes.forEach((child) => child.remove());
+    }
+
     graphviz(`#${this.id}`)
       .options({
         ...Graphviz.defaultOptions,


### PR DESCRIPTION
Currently (as per #29)  if `zoom` is enabled for a graph then disabling will have no effect and scrolling will still zoom in and out of the graph. The expected behaviour is that disabling zoom should prevent the graph from scaling in and out on scroll.

This appears to be a bug in the underlying package (`d3-graphviz`) and there is an open issue for it there: [d3-graphviz#180](https://github.com/magjac/d3-graphviz/issues/180) but because `d3-graphviz` is a major version ahead of `graphviz-react` any bugfix may not be backported to the version used by `graphviz-react`. Therefore we are putting a fix in place here until we are able to upgrade to the latest version to ensure the behaviour is as expected.