### PR TITLE
Add missing package type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "graphviz-react",
   "version": "1.2.0",
   "description": "React component for displaying Graphviz graphs",
+  "type": "module",
   "main": "./lib/Graphviz.js",
   "types": "./lib/Graphviz.d.ts",
   "scripts": {


### PR DESCRIPTION
This PR adds the missing package type definition. It makes it possible to import the package without having to transpile the code before import. See issue #47 for problem description.