### PR TITLE
Pass options in constructor to avoid useWorker warning

### DIFF
--- a/src/Graphviz.tsx
+++ b/src/Graphviz.tsx
@@ -33,12 +33,10 @@ const Graphviz = ({ dot, className, options = {} }: IGraphvizProps) => {
   const id = useMemo(getId, []);
 
   useEffect(() => {
-    graphviz(`#${id}`)
-      .options({
-        ...defaultOptions,
-        ...options,
-      })
-      .renderDot(dot);
+    graphviz(`#${id}`, {
+      ...defaultOptions,
+      ...options,
+    }).renderDot(dot);
   }, [dot, options]);
 
   return <div className={className} id={id} />;


### PR DESCRIPTION
Currently, the argument options are being passed to graphviz after object construction via the .options method.  This works fine, but during initialization graphviz may log a warning about useWorker even when the option `{ useWorker: false}` is passed because the options are being passed in too late.

By merging this, we are allowing people to disable `useWorker` without having a noisy warning in their console.
Related Issue #55 

Right now this component throws the below error
```typescript
import Graphviz from 'graphviz-react';

function WorkflowRenderer(props: Props) {
    const { title, workflow } = props;
    const classes = useStyles();
    const dotString = makeDotString(workflow);
    return (
        <>
            <div className={classes.taller}>
                <Heading>{title || 'Preview:'}</Heading>
                <Graphviz dot={dotString} options={{ useWorker: false }} />
            </div>
        </>
    );
}
```

![Screen Shot 2022-08-31 at 9 46 20 AM](https://user-images.githubusercontent.com/48340767/187734627-c31959d8-32ee-46ac-ad95-b3f98acc5ea7.png)
