### PR TITLE
Expose Callback function in d3-graphviz

### DIFF
--- a/src/Graphviz.tsx
+++ b/src/Graphviz.tsx
@@ -16,6 +16,10 @@ interface IGraphvizProps {
    * The classname to attach to this component for styling purposes.
    */
   className?: string;
+  /**
+   * The callback function to call when the graph is rendered.
+   */
+  callback?: () => void;
 }
 
 const defaultOptions: GraphvizOptions = {
@@ -29,14 +33,14 @@ let counter = 0;
 // eslint-disable-next-line no-plusplus
 const getId = () => `graphviz${counter++}`;
 
-const Graphviz = ({ dot, className, options = {} }: IGraphvizProps) => {
+const Graphviz = ({ dot, className, options = {}, callback }: IGraphvizProps) => {
   const id = useMemo(getId, []);
 
   useEffect(() => {
     graphviz(`#${id}`, {
       ...defaultOptions,
       ...options,
-    }).renderDot(dot);
+    }).renderDot(dot, callback);
   }, [dot, options]);
 
   return <div className={className} id={id} />;

--- a/src/Graphviz.tsx
+++ b/src/Graphviz.tsx
@@ -33,7 +33,12 @@ let counter = 0;
 // eslint-disable-next-line no-plusplus
 const getId = () => `graphviz${counter++}`;
 
-const Graphviz = ({ dot, className, options = {}, callback }: IGraphvizProps) => {
+const Graphviz = ({
+  dot,
+  className,
+  options = {},
+  callback,
+}: IGraphvizProps) => {
   const id = useMemo(getId, []);
 
   useEffect(() => {


### PR DESCRIPTION
This exposes the underlying `callback` function which is called when the rendering state changes. For large files, it can take a while for the graph to "show", hence this helps creates better progress bars if someone needs them.

This is based off the source file:

[https://github.com/magjac/d3-graphviz/blob/master/src/renderDot.js](url)